### PR TITLE
[dev] fix: project array definition corrected

### DIFF
--- a/website/api/retrieveProjectHeaders.ts
+++ b/website/api/retrieveProjectHeaders.ts
@@ -6,7 +6,7 @@ export async function getData() {
   const sql = neon(db_url)
 
   const data = await sql`SELECT * FROM project_headers`
-  console.log(data)
+  // console.log(data)
   return data
 }
 

--- a/website/src/views/WorkView.vue
+++ b/website/src/views/WorkView.vue
@@ -5,7 +5,17 @@ import SmallCard from '../components/ProjectSmallCard.vue'
 
 import '@/assets/views/work.css'
 
-const projects = ref([])
+interface Project {
+  id: string
+  project_name: string
+  description: string
+  image: string
+  link: string
+  link_text: string
+  component_name: string
+}
+
+const projects = ref<Project[]>([])
 
 async function retrieveProjectHeaders() {
   try {


### PR DESCRIPTION
This pull request includes changes to improve code readability and add type definitions in the `website` project. The most important changes include commenting out a debug statement in the `retrieveProjectHeaders.ts` file and defining an interface for project data in the `WorkView.vue` file.

Improvements to code readability:

* [`website/api/retrieveProjectHeaders.ts`](diffhunk://#diff-884f1cb6ebfd270b2bebd4e9c650b2e9d4ae2123667b0c4212ba6c41c3ccaf3eL9-R9): Commented out a debug `console.log` statement to clean up the code.

Type definitions:

* [`website/src/views/WorkView.vue`](diffhunk://#diff-3880948927f328cd6c05d8b334d1a766fb607127fc82320a9266915149ea27cdL8-R18): Added an interface `Project` to define the structure of project data and used it to type the `projects` array.